### PR TITLE
Improve Codex start scripts to honor persistent env

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,5 +1,30 @@
-#!/bin/bash
-cd "/workspace/edi-lens/backend"
-source venv/bin/activate
-source "/workspace/edi-lens/.env.codex"
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$SCRIPT_DIR"
+REPO_ROOT="$(cd "$BACKEND_DIR/.." && pwd)"
+
+DEFAULT_ENV_FILE="$REPO_ROOT/.env.codex"
+PERSISTENT_ENV_FILE="/opt/codex-services/.env.codex"
+
+if [ -f "$PERSISTENT_ENV_FILE" ]; then
+    ACTIVE_ENV_FILE="$PERSISTENT_ENV_FILE"
+else
+    ACTIVE_ENV_FILE="$DEFAULT_ENV_FILE"
+fi
+
+if [ -f "$BACKEND_DIR/venv/bin/activate" ]; then
+    # shellcheck source=/dev/null
+    source "$BACKEND_DIR/venv/bin/activate"
+fi
+
+if [ -f "$ACTIVE_ENV_FILE" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ACTIVE_ENV_FILE"
+    set +a
+fi
+
+cd "$BACKEND_DIR"
 exec poetry run uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload

--- a/frontend/start.sh
+++ b/frontend/start.sh
@@ -1,4 +1,25 @@
-#!/bin/bash
-cd "/workspace/edi-lens/frontend"
-source "/workspace/edi-lens/.env.codex"
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$SCRIPT_DIR"
+REPO_ROOT="$(cd "$FRONTEND_DIR/.." && pwd)"
+
+DEFAULT_ENV_FILE="$REPO_ROOT/.env.codex"
+PERSISTENT_ENV_FILE="/opt/codex-services/.env.codex"
+
+if [ -f "$PERSISTENT_ENV_FILE" ]; then
+    ACTIVE_ENV_FILE="$PERSISTENT_ENV_FILE"
+else
+    ACTIVE_ENV_FILE="$DEFAULT_ENV_FILE"
+fi
+
+if [ -f "$ACTIVE_ENV_FILE" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ACTIVE_ENV_FILE"
+    set +a
+fi
+
+cd "$FRONTEND_DIR"
 exec npm run dev -- --host 0.0.0.0 --port 3000

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -1022,12 +1022,37 @@ setup_backend() {
         error "Database migrations failed"
     fi
 
-    # Create start script
-    cat > start.sh <<EOF
-#!/bin/bash
-cd "$PROJECT_ROOT/backend"
-source venv/bin/activate
-source "$ENV_FILE"
+    # Create start script (idempotent and environment-aware)
+    cat > start.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$SCRIPT_DIR"
+REPO_ROOT="$(cd "$BACKEND_DIR/.." && pwd)"
+
+DEFAULT_ENV_FILE="$REPO_ROOT/.env.codex"
+PERSISTENT_ENV_FILE="/opt/codex-services/.env.codex"
+
+if [ -f "$PERSISTENT_ENV_FILE" ]; then
+    ACTIVE_ENV_FILE="$PERSISTENT_ENV_FILE"
+else
+    ACTIVE_ENV_FILE="$DEFAULT_ENV_FILE"
+fi
+
+if [ -f "$BACKEND_DIR/venv/bin/activate" ]; then
+    # shellcheck source=/dev/null
+    source "$BACKEND_DIR/venv/bin/activate"
+fi
+
+if [ -f "$ACTIVE_ENV_FILE" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ACTIVE_ENV_FILE"
+    set +a
+fi
+
+cd "$BACKEND_DIR"
 exec poetry run uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
 EOF
     chmod +x start.sh
@@ -1114,11 +1139,32 @@ setup_frontend() {
         fi
     fi
 
-    # Create start script
-    cat > start.sh <<EOF
-#!/bin/bash
-cd "$PROJECT_ROOT/frontend"
-source "$ENV_FILE"
+    # Create start script (idempotent and environment-aware)
+    cat > start.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$SCRIPT_DIR"
+REPO_ROOT="$(cd "$FRONTEND_DIR/.." && pwd)"
+
+DEFAULT_ENV_FILE="$REPO_ROOT/.env.codex"
+PERSISTENT_ENV_FILE="/opt/codex-services/.env.codex"
+
+if [ -f "$PERSISTENT_ENV_FILE" ]; then
+    ACTIVE_ENV_FILE="$PERSISTENT_ENV_FILE"
+else
+    ACTIVE_ENV_FILE="$DEFAULT_ENV_FILE"
+fi
+
+if [ -f "$ACTIVE_ENV_FILE" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ACTIVE_ENV_FILE"
+    set +a
+fi
+
+cd "$FRONTEND_DIR"
 exec npm run dev -- --host 0.0.0.0 --port 3000
 EOF
     chmod +x start.sh


### PR DESCRIPTION
## Summary
- make backend and frontend start scripts resolve the repository dynamically and prefer the persistent Codex env file when available
- update the Codex setup script to emit the same resilient start script templates so rerunning the setup leaves the repo clean

## Testing
- bash -n backend/start.sh frontend/start.sh scripts/setup_codex.sh

------
https://chatgpt.com/codex/tasks/task_e_68d0368cc33c832aa035074c542f048f