### PR TITLE
Ensure Codex setup refreshes Poetry dependencies

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -4,7 +4,7 @@ Welcome to the EDI Lens backend. This service is a FastAPI application that orch
 
 ## Local Development Environment
 
-* **Python toolchain**: managed with [Poetry](https://python-poetry.org/). Always install dependencies with `poetry install --with dev` before running tests or linting.
+* **Python toolchain**: managed with [Poetry](https://python-poetry.org/). The Codex setup script automatically runs `poetry install --with dev` inside the backend virtual environment; avoid re-running it manually unless you are developing outside the Codex automation.
 * **Entry point**: FastAPI app and supporting services live under `src/`. Clients that call NiFi and Registry APIs reside in `src/clients`, domain services in `src/services`, and workflow orchestration in `src/services/workflow_orchestrator.py`.
 * **Environment configuration**: default runtime settings are defined via `.env` (optional) and test fixtures in `tests/env`. When `.env.local` is absent, local test runs fall back to localhost defaults that assume Docker services on standard ports (NiFi 8443, Registry 18080, Backend 8000, Postgres 5432).
 

--- a/scripts/codex/setup_codex.sh
+++ b/scripts/codex/setup_codex.sh
@@ -1095,26 +1095,24 @@ setup_backend() {
 
     cd "$PROJECT_ROOT/backend"
 
-    # Check if virtual environment already exists and is configured
-    if [ -f "venv/bin/activate" ] && [ -f "start.sh" ]; then
-        info "Backend virtual environment already configured"
-        # Just run migrations if needed
-        source venv/bin/activate
-        source "$ENV_FILE"
-        poetry run alembic upgrade head
-        success "Backend configuration updated"
-        return 0
+    local created_venv=false
+    if [ ! -f "venv/bin/activate" ]; then
+        info "Creating backend virtual environment"
+        python3 -m venv venv
+        created_venv=true
+    else
+        info "Reusing existing backend virtual environment"
     fi
 
-    # Create virtual environment
-    python3 -m venv venv
+    # shellcheck source=/dev/null
     source venv/bin/activate
 
-    # Install poetry
+    # Install Poetry every time so dependency updates are picked up even when
+    # the cached Codex environment persists between tasks.
     pip install --upgrade pip poetry
 
-    # Install dependencies
-    poetry install
+    info "Installing backend dependencies via Poetry"
+    poetry install --with dev
 
     # Run database migrations
     info "Running database migrations..."
@@ -1158,7 +1156,11 @@ exec poetry run uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
 EOF
     chmod +x start.sh
 
-    success "Backend configured"
+    if [ "$created_venv" = true ]; then
+        success "Backend virtual environment created and configured"
+    else
+        success "Backend virtual environment refreshed and configured"
+    fi
 }
 
 setup_frontend() {


### PR DESCRIPTION
## Summary
- always (re)create and activate the backend virtualenv before installing dependencies when running the Codex setup script
- reinstall Poetry and run `poetry install --with dev` on each run so cached Codex environments pick up dependency changes
- update backend agent guidance to note the setup script already installs Poetry dependencies automatically

## Testing
- bash -n scripts/codex/setup_codex.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2b70402a4832abeafbd355754a55d