### PR TITLE
Document ignoring legacy directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ The project uses `.env.local` for all environment configuration:
 - Backend dependencies are managed with Poetry
 - All services run on localhost with standard ports
 - Check service health with maintenance script before testing
+- Ignore any directories that end with `_legacy`; they contain deprecated code that should not be modified or considered during development or reviews.
 
 ## 🆘 Troubleshooting
 


### PR DESCRIPTION
## Summary
- add documentation to the agent guide clarifying that *_legacy directories contain deprecated code and should be ignored

## Testing
- ./scripts/backend.sh test unit
- ./scripts/backend.sh test integration

------
https://chatgpt.com/codex/tasks/task_e_68d38e2b64f8832a93ac601ee6493131