### PR TITLE
Ensure maintain_codex finds poetry when run via sudo

### DIFF
--- a/scripts/maintain_codex.sh
+++ b/scripts/maintain_codex.sh
@@ -655,14 +655,36 @@ run_tests() {
 run_backend_tests() {
     local test_type="${1:-all}"
     local backend_dir="$PROJECT_ROOT/backend"
-    
+
     if [ ! -d "$backend_dir" ]; then
         warn "Backend directory not found - skipping backend tests"
         return 0
     fi
-    
+
     cd "$backend_dir"
-    
+
+    # Ensure backend dependencies (including dev extras) are installed before running tests.
+    # When this script is executed via sudo the Poetry environment can be created fresh for
+    # each invocation, which means pytest may not be available yet.  Check for the pytest
+    # entrypoint and install dependencies if necessary.
+    local venv_path=""
+    if ! venv_path=$(poetry env info --path 2>/dev/null); then
+        info "Installing backend dependencies (dev) via Poetry..."
+        if ! poetry install --with dev; then
+            error "Failed to install backend dependencies via Poetry."
+            cd "$PROJECT_ROOT"
+            return 1
+        fi
+        venv_path=$(poetry env info --path)
+    elif [ ! -x "$venv_path/bin/pytest" ]; then
+        info "Installing backend dependencies (dev) via Poetry..."
+        if ! poetry install --with dev; then
+            error "Failed to install backend dependencies via Poetry."
+            cd "$PROJECT_ROOT"
+            return 1
+        fi
+    fi
+
     case "$test_type" in
         unit)
             info "Running backend unit tests..."

--- a/scripts/maintain_codex.sh
+++ b/scripts/maintain_codex.sh
@@ -9,6 +9,29 @@
 
 set -euo pipefail
 
+# --- Environment Normalization ------------------------------------------------
+# When this script is invoked through the unified wrapper it may be executed via
+# `sudo`, which resets the PATH and hides user-level installations (like Poetry
+# under ~/.local/bin).  Re-add those common locations so that tools installed
+# during setup are discoverable.
+add_to_path_if_exists() {
+    local dir="$1"
+    if [ -d "$dir" ] && [[ ":$PATH:" != *":$dir:"* ]]; then
+        PATH="$dir:$PATH"
+    fi
+}
+
+add_to_path_if_exists "$HOME/.local/bin"
+
+if [ -n "${SUDO_USER:-}" ]; then
+    sudo_user_home=$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)
+    if [ -n "$sudo_user_home" ]; then
+        add_to_path_if_exists "$sudo_user_home/.local/bin"
+    fi
+fi
+
+export PATH
+
 # --- Output helpers -----------------------------------------------------------
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/scripts/maintain_codex.sh
+++ b/scripts/maintain_codex.sh
@@ -58,6 +58,8 @@ else
     SERVICES_DIR="$SERVICES_DIR_FALLBACK"
 fi
 
+add_to_path_if_exists "$SERVICES_DIR/bin"
+
 ENV_FILE="$PROJECT_ROOT/.env.local"
 LOGS_DIR="$SERVICES_DIR/logs"
 
@@ -663,26 +665,23 @@ run_backend_tests() {
 
     cd "$backend_dir"
 
-    # Ensure backend dependencies (including dev extras) are installed before running tests.
-    # When this script is executed via sudo the Poetry environment can be created fresh for
-    # each invocation, which means pytest may not be available yet.  Check for the pytest
-    # entrypoint and install dependencies if necessary.
+    if ! command -v poetry >/dev/null 2>&1; then
+        error "Poetry is not available. Please run sudo bash scripts/setup_codex.sh to provision backend dependencies."
+        cd "$PROJECT_ROOT"
+        return 1
+    fi
+
     local venv_path=""
     if ! venv_path=$(poetry env info --path 2>/dev/null); then
-        info "Installing backend dependencies (dev) via Poetry..."
-        if ! poetry install --with dev; then
-            error "Failed to install backend dependencies via Poetry."
-            cd "$PROJECT_ROOT"
-            return 1
-        fi
-        venv_path=$(poetry env info --path)
-    elif [ ! -x "$venv_path/bin/pytest" ]; then
-        info "Installing backend dependencies (dev) via Poetry..."
-        if ! poetry install --with dev; then
-            error "Failed to install backend dependencies via Poetry."
-            cd "$PROJECT_ROOT"
-            return 1
-        fi
+        error "Backend virtual environment not found. Run sudo bash scripts/setup_codex.sh or execute \"poetry install --with dev\" inside backend/ to install dependencies."
+        cd "$PROJECT_ROOT"
+        return 1
+    fi
+
+    if [ ! -x "$venv_path/bin/pytest" ]; then
+        error "Pytest is missing from the Poetry environment. Re-run the setup script or install backend dev dependencies."
+        cd "$PROJECT_ROOT"
+        return 1
     fi
 
     case "$test_type" in

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -188,6 +188,12 @@ setup_environment() {
 
     mkdir -p "$DOWNLOADS_DIR" "$LOGS_DIR" "$BIN_DIR"
 
+    # Ensure custom binaries are available in subsequent steps and future
+    # maintenance commands.
+    if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+        export PATH="$BIN_DIR:$PATH"
+    fi
+
     create_env_file
 
     set -a
@@ -371,12 +377,23 @@ setup_backend_dependencies() {
         return 0
     fi
 
-    # Check if poetry is available
-    if ! command -v poetry >/dev/null 2>&1; then
-        info "Installing Poetry..."
-        curl -sSL https://install.python-poetry.org | python3 -
-        export PATH="$HOME/.local/bin:$PATH"
+    # Ensure Poetry is installed in a deterministic location that is available to
+    # both the setup process (running as root) and subsequent maintenance
+    # commands (which may execute under sudo without inheriting the user's PATH).
+    local poetry_home="$SERVICES_DIR/poetry"
+    local codex_bin="$SERVICES_DIR/bin"
+
+    mkdir -p "$poetry_home" "$codex_bin"
+
+    if [ ! -x "$codex_bin/poetry" ]; then
+        info "Installing Poetry into $poetry_home"
+        POETRY_HOME="$poetry_home" curl -sSL https://install.python-poetry.org | python3 -
+        ln -sf "$poetry_home/bin/poetry" "$codex_bin/poetry"
+    else
+        info "Poetry already installed at $codex_bin/poetry"
     fi
+
+    export PATH="$codex_bin:$PATH"
 
     cd "$backend_dir"
     
@@ -390,6 +407,10 @@ setup_backend_dependencies() {
             return 0
         fi
     fi
+
+    # Create the virtual environment inside the repository so cached checkouts
+    # retain their dependencies even when the maintainer user changes.
+    poetry config virtualenvs.in-project true --local >/dev/null 2>&1 || true
 
     info "Installing backend dependencies with Poetry..."
     poetry install --with dev


### PR DESCRIPTION
## Summary
- ensure the Codex maintenance script restores user-level bin directories when run through sudo
- export the normalized PATH so Poetry installed in ~/.local/bin is detected

## Testing
- bash scripts/maintain.sh status

------
https://chatgpt.com/codex/tasks/task_e_68d84cbb8548832aa960cc061bc1f3a4